### PR TITLE
Wort verschoben: '20 etwa [APIs]'→'etwa 20 [APIs]'

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -100,7 +100,7 @@
         </v-card>
       </v-col>
       <v-col class="col-12 all-apis">
-        <p>Momentan bieten wir Ihnen insgesamt Dokumentationen zu 20 etwa Programmierschnittstellen an.</p>
+        <p>Momentan bieten wir Ihnen insgesamt Dokumentationen zu etwa 20 Programmierschnittstellen an.</p>
             <a href="/apis" class="all-apis-btn">
               <span class="doc-btn">Alle APIs</span>
             </a>


### PR DESCRIPTION
in der Annahme, dass sich "etwa" auf die Anzahl beziehen soll und nicht darauf, ob das Programmierschnittstellen sind